### PR TITLE
feat: add Supabase auth UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Copiez `.env.example` vers `.env` et renseignez :
 - `VITE_SUPABASE_ANON_KEY`
 - `VITE_API_BASE_URL`
 
+## Tests manuels
+
+1. `npm run dev`
+2. Ouvrir `http://localhost:5173`
+3. Créer un compte via `/auth/register` ou se connecter sur `/auth/login`.
+4. Les routes `/app`, `/app/new`, `/app/history` et `/app/profile` nécessitent une session active.
+5. Pour réinitialiser le mot de passe, utiliser `/auth/reset` puis suivre le lien envoyé vers `/auth/update-password`.
+
 ## Licence
 
 [MIT](./LICENSE)

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,4 +1,10 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  Navigate,
+  useNavigate,
+} from 'react-router-dom';
 import type { ReactNode } from 'react';
 import { LoginPage } from '../features/auth/LoginPage';
 import { RegisterPage } from '../features/auth/RegisterPage';
@@ -7,10 +13,30 @@ import { NewPage } from '../features/generate/NewPage';
 import { HistoryPage } from '../features/history/HistoryPage';
 import { DashboardPage } from './pages/DashboardPage';
 import { useAuth } from '../features/auth/AuthProvider';
+import { ResetPasswordPage } from '../features/auth/ResetPasswordPage';
+import { UpdatePasswordPage } from '../features/auth/UpdatePasswordPage';
 
-const PrivateRoute = ({ children }: { children: ReactNode }) => {
-  const { user } = useAuth();
-  return user ? <>{children}</> : <Navigate to="/auth/login" />;
+const RequireAuth = ({ children }: { children: ReactNode }) => {
+  const { user, signOut } = useAuth();
+  const navigate = useNavigate();
+  if (!user) return <Navigate to="/auth/login" />;
+  const handleSignOut = async () => {
+    await signOut();
+    navigate('/auth/login');
+  };
+  return (
+    <div className="min-h-screen">
+      <header className="flex justify-end border-b p-4">
+        <button
+          onClick={handleSignOut}
+          className="rounded bg-gray-200 px-4 py-2"
+        >
+          Se déconnecter
+        </button>
+      </header>
+      {children}
+    </div>
+  );
 };
 
 export const AppRoutes = () => (
@@ -18,36 +44,38 @@ export const AppRoutes = () => (
     <Routes>
       <Route path="/auth/login" element={<LoginPage />} />
       <Route path="/auth/register" element={<RegisterPage />} />
+      <Route path="/auth/reset" element={<ResetPasswordPage />} />
+      <Route path="/auth/update-password" element={<UpdatePasswordPage />} />
       <Route
         path="/app"
         element={
-          <PrivateRoute>
+          <RequireAuth>
             <DashboardPage />
-          </PrivateRoute>
+          </RequireAuth>
         }
       />
       <Route
         path="/app/new"
         element={
-          <PrivateRoute>
+          <RequireAuth>
             <NewPage />
-          </PrivateRoute>
+          </RequireAuth>
         }
       />
       <Route
         path="/app/history"
         element={
-          <PrivateRoute>
+          <RequireAuth>
             <HistoryPage />
-          </PrivateRoute>
+          </RequireAuth>
         }
       />
       <Route
         path="/app/profile"
         element={
-          <PrivateRoute>
+          <RequireAuth>
             <ProfilePage />
-          </PrivateRoute>
+          </RequireAuth>
         }
       />
       <Route path="*" element={<Navigate to="/app" />} />

--- a/src/features/auth/AuthProvider.tsx
+++ b/src/features/auth/AuthProvider.tsx
@@ -1,13 +1,29 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
-import type { User } from '@supabase/supabase-js';
+import type { User, AuthError } from '@supabase/supabase-js';
 import { supabase } from '../../lib/supabaseClient';
 
 interface AuthContextValue {
   user: User | null;
+  signIn: (
+    email: string,
+    password: string,
+  ) => Promise<{ error: AuthError | null }>;
+  signUp: (
+    email: string,
+    password: string,
+  ) => Promise<{ error: AuthError | null }>;
+  signOut: () => Promise<{ error: AuthError | null }>;
+  resetPassword: (email: string) => Promise<{ error: AuthError | null }>;
 }
 
-const AuthContext = createContext<AuthContextValue>({ user: null });
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  signIn: async () => ({ error: null }),
+  signUp: async () => ({ error: null }),
+  signOut: async () => ({ error: null }),
+  resetPassword: async () => ({ error: null }),
+});
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
@@ -22,8 +38,22 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     return () => subscription.unsubscribe();
   }, []);
 
+  const signIn = (email: string, password: string) =>
+    supabase.auth.signInWithPassword({ email, password });
+  const signUp = (email: string, password: string) =>
+    supabase.auth.signUp({ email, password });
+  const signOut = () => supabase.auth.signOut();
+  const resetPassword = (email: string) =>
+    supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}/auth/update-password`,
+    });
+
   return (
-    <AuthContext.Provider value={{ user }}>{children}</AuthContext.Provider>
+    <AuthContext.Provider
+      value={{ user, signIn, signUp, signOut, resetPassword }}
+    >
+      {children}
+    </AuthContext.Provider>
   );
 };
 

--- a/src/features/auth/RegisterPage.tsx
+++ b/src/features/auth/RegisterPage.tsx
@@ -1,5 +1,63 @@
-export const RegisterPage = () => (
-  <div className="flex min-h-screen items-center justify-center">
-    <h1 className="text-2xl font-bold">Register</h1>
-  </div>
-);
+import { useState } from 'react';
+import type { FormEvent } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from './AuthProvider';
+
+export const RegisterPage = () => {
+  const { signUp } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const { error } = await signUp(email, password);
+    if (error) {
+      setError(error.message);
+    } else {
+      navigate('/app');
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-xs space-y-4">
+        <h1 className="text-center text-2xl font-bold">Créer mon compte</h1>
+        <input
+          className="w-full rounded border p-2"
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          className="w-full rounded border p-2"
+          type="password"
+          placeholder="Mot de passe"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <button
+          type="submit"
+          className="w-full rounded bg-blue-500 px-4 py-2 text-white"
+        >
+          Créer mon compte
+        </button>
+        {error && (
+          <p role="alert" className="text-sm text-red-500">
+            {error}
+          </p>
+        )}
+        <p className="text-center text-sm">
+          Déjà inscrit ?{' '}
+          <Link to="/auth/login" className="text-blue-600">
+            Se connecter
+          </Link>
+        </p>
+      </form>
+    </div>
+  );
+};

--- a/src/features/auth/ResetPasswordPage.tsx
+++ b/src/features/auth/ResetPasswordPage.tsx
@@ -1,29 +1,32 @@
 import { useState } from 'react';
 import type { FormEvent } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useAuth } from './AuthProvider';
 
-export const LoginPage = () => {
-  const { signIn } = useAuth();
-  const navigate = useNavigate();
+export const ResetPasswordPage = () => {
+  const { resetPassword } = useAuth();
   const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    const { error } = await signIn(email, password);
+    setMessage(null);
+    const { error } = await resetPassword(email);
     if (error) {
       setError(error.message);
     } else {
-      navigate('/app');
+      setError(null);
+      setMessage('Vérifiez vos e-mails.');
     }
   };
 
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
       <form onSubmit={handleSubmit} className="w-full max-w-xs space-y-4">
-        <h1 className="text-center text-2xl font-bold">Se connecter</h1>
+        <h1 className="text-center text-2xl font-bold">
+          Réinitialiser le mot de passe
+        </h1>
         <input
           className="w-full rounded border p-2"
           type="email"
@@ -32,32 +35,21 @@ export const LoginPage = () => {
           onChange={(e) => setEmail(e.target.value)}
           required
         />
-        <input
-          className="w-full rounded border p-2"
-          type="password"
-          placeholder="Mot de passe"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-        />
         <button
           type="submit"
           className="w-full rounded bg-blue-500 px-4 py-2 text-white"
         >
-          Se connecter
+          Envoyer le lien
         </button>
+        {message && <p className="text-sm text-green-600">{message}</p>}
         {error && (
           <p role="alert" className="text-sm text-red-500">
             {error}
           </p>
         )}
         <p className="text-center text-sm">
-          <Link to="/auth/register" className="text-blue-600">
-            Créer mon compte
-          </Link>{' '}
-          ·{' '}
-          <Link to="/auth/reset" className="text-blue-600">
-            Mot de passe oublié ?
+          <Link to="/auth/login" className="text-blue-600">
+            Se connecter
           </Link>
         </p>
       </form>

--- a/src/features/auth/UpdatePasswordPage.tsx
+++ b/src/features/auth/UpdatePasswordPage.tsx
@@ -1,18 +1,16 @@
 import { useState } from 'react';
 import type { FormEvent } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
-import { useAuth } from './AuthProvider';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '../../lib/supabaseClient';
 
-export const LoginPage = () => {
-  const { signIn } = useAuth();
+export const UpdatePasswordPage = () => {
   const navigate = useNavigate();
-  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    const { error } = await signIn(email, password);
+    const { error } = await supabase.auth.updateUser({ password });
     if (error) {
       setError(error.message);
     } else {
@@ -23,19 +21,11 @@ export const LoginPage = () => {
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
       <form onSubmit={handleSubmit} className="w-full max-w-xs space-y-4">
-        <h1 className="text-center text-2xl font-bold">Se connecter</h1>
-        <input
-          className="w-full rounded border p-2"
-          type="email"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-        />
+        <h1 className="text-center text-2xl font-bold">Nouveau mot de passe</h1>
         <input
           className="w-full rounded border p-2"
           type="password"
-          placeholder="Mot de passe"
+          placeholder="Nouveau mot de passe"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
@@ -44,22 +34,13 @@ export const LoginPage = () => {
           type="submit"
           className="w-full rounded bg-blue-500 px-4 py-2 text-white"
         >
-          Se connecter
+          Mettre à jour
         </button>
         {error && (
           <p role="alert" className="text-sm text-red-500">
             {error}
           </p>
         )}
-        <p className="text-center text-sm">
-          <Link to="/auth/register" className="text-blue-600">
-            Créer mon compte
-          </Link>{' '}
-          ·{' '}
-          <Link to="/auth/reset" className="text-blue-600">
-            Mot de passe oublié ?
-          </Link>
-        </p>
       </form>
     </div>
   );

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL,
+  import.meta.env.VITE_SUPABASE_ANON_KEY,
+);


### PR DESCRIPTION
## Summary
- implement Supabase client and auth provider
- add email/password auth pages and protected routes
- document env vars and manual test steps

## Testing
- `npm run lint`
- `npm run build`

## Screens
- /auth/register
- /auth/login
- /auth/reset
- /auth/update-password

------
https://chatgpt.com/codex/tasks/task_e_68a6f070e75483309c1124e2138b8577